### PR TITLE
fix: refactor graph height calculation to a focused calculator

### DIFF
--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
@@ -13,7 +13,7 @@ class GraphParser(private val fileGraph: String) {
     private val decimalFormat = DecimalFormat("#.##")
     private val result: SimpleDirectedGraph<String, DefaultEdge>
     private val betweennessCentrality: Map<String, Double>
-    private val nodes = mutableMapOf<String, Node>()
+    private val heightCalculator = HeightCalculator()
 
     init {
         checkFile()
@@ -27,7 +27,7 @@ class GraphParser(private val fileGraph: String) {
             it.toString().removeSurrounding("(", ")").replace(".", "_").split(" : ")
                 .let { parts -> parts[0] to parts[1] }
         }
-        edgesParsed.forEach { (from, to) -> addEdge(from, to) }
+        edgesParsed.forEach { (from, to) -> heightCalculator.addEdge(from, to) }
         betweennessCentrality = BetweennessCentrality(result).scores
     }
 
@@ -54,32 +54,7 @@ class GraphParser(private val fileGraph: String) {
         0
     }
 
-    fun heightOf(key: String): Int = nodes[key]?.height() ?: -1
-
-
-    class Node(val key: String) {
-        val dependsOn = mutableSetOf<Node>()
-        private var visited = false
-        private var calculatedHeight = -1
-
-        fun height(): Int {
-            if (visited) return 0
-            if (calculatedHeight == -1) {
-                visited = true
-                calculatedHeight = if (dependsOn.isEmpty()) 0 else (1 + dependsOn.maxOfOrNull { it.height() }!!)
-                visited = false
-            }
-            return calculatedHeight
-        }
-    }
-
-    private fun addEdge(from: String, to: String) {
-        getOrCreate(from).dependsOn.add(getOrCreate(to))
-    }
-
-    private fun getOrCreate(key: String): Node {
-        return nodes.getOrPut(key) { Node(key) }
-    }
+    fun heightOf(key: String): Int = heightCalculator.heightOf(key)
 
     fun getIndicatorsByModule(): Map<String, GraphMetric> {
         return result().vertexSet().associateWith {

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculator.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculator.kt
@@ -1,0 +1,31 @@
+package io.github.cdsap.projectgraphmetrics.parser
+
+internal class HeightCalculator {
+    private val nodes = mutableMapOf<String, Node>()
+
+    fun addEdge(from: String, to: String) {
+        getOrCreate(from).dependsOn.add(getOrCreate(to))
+    }
+
+    fun heightOf(key: String): Int = nodes[key]?.height() ?: -1
+
+    private fun getOrCreate(key: String): Node {
+        return nodes.getOrPut(key) { Node(key) }
+    }
+
+    private class Node(val key: String) {
+        val dependsOn = mutableSetOf<Node>()
+        private var visited = false
+        private var calculatedHeight = -1
+
+        fun height(): Int {
+            if (visited) return 0
+            if (calculatedHeight == -1) {
+                visited = true
+                calculatedHeight = if (dependsOn.isEmpty()) 0 else (1 + dependsOn.maxOfOrNull { it.height() }!!)
+                visited = false
+            }
+            return calculatedHeight
+        }
+    }
+}

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculatorTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculatorTest.kt
@@ -1,0 +1,42 @@
+package io.github.cdsap.projectgraphmetrics.parser
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HeightCalculatorTest {
+
+    @Test
+    fun heightOfSimpleDependencyChain() {
+        val calculator = HeightCalculator()
+        calculator.addEdge("A", "B")
+        calculator.addEdge("B", "C")
+
+        assertEquals(0, calculator.heightOf("C"))
+        assertEquals(1, calculator.heightOf("B"))
+        assertEquals(2, calculator.heightOf("A"))
+    }
+
+    @Test
+    fun heightOfUnknownModuleIsMinusOne() {
+        val calculator = HeightCalculator()
+        calculator.addEdge("A", "B")
+
+        assertEquals(-1, calculator.heightOf("missing"))
+    }
+
+    @Test
+    fun cycleGuardReturnsFiniteHeight() {
+        val calculator = HeightCalculator()
+        calculator.addEdge("A", "B")
+        calculator.addEdge("B", "A")
+
+        val heightA = calculator.heightOf("A")
+        val heightB = calculator.heightOf("B")
+
+        assertTrue(heightA >= 0)
+        assertTrue(heightB >= 0)
+        assertEquals(2, heightA)
+        assertEquals(1, heightB)
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt:18` imports the DOT file, owns the JGraphT graph, calculates betweenness/degree metrics, and also contains the mutable `Node` height traversal state at `GraphParser.kt:60`. This makes the parser responsible for both infrastructure parsing and a core graph metric algorithm.

### Why this matters

The height algorithm is currently hard to test without constructing a DOT file and running the full parser/import path. Any change to height semantics risks being hidden behind file parsing, JGraphT importer behavior, and metric aggregation.

### Proposed change

Extract the `Node`, `addEdge`, `getOrCreate`, and `heightOf` behavior into a small internal `HeightCalculator` in the parser package. `GraphParser` should keep importing the DOT graph and deriving edge pairs, then delegate height lookups to the calculator when building `GraphMetric`.

### Notes

This keeps DOT/JGraphT importing as infrastructure in `GraphParser` while moving one core metric rule into a small, independently testable component.

Fixes #49

## Changes

- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculator.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculatorTest.kt`

## Verification

- `./gradlew test`
