### PR TITLE
fix: refactor graphparser to separate dot loading from metric calculatio

### DIFF
--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/DotGraphLoader.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/DotGraphLoader.kt
@@ -1,0 +1,26 @@
+package io.github.cdsap.projectgraphmetrics.parser
+
+import org.jgrapht.graph.DefaultEdge
+import org.jgrapht.graph.SimpleDirectedGraph
+import org.jgrapht.nio.dot.DOTImporter
+import java.io.File
+import java.io.FileNotFoundException
+
+internal class DotGraphLoader {
+
+    fun load(fileGraph: String): SimpleDirectedGraph<String, DefaultEdge> {
+        checkFile(fileGraph)
+        val importer = DOTImporter<String, DefaultEdge>().apply {
+            setVertexFactory { it }
+        }
+        val graph = SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
+        importer.importGraph(graph, File(fileGraph))
+        return graph
+    }
+
+    private fun checkFile(fileGraph: String) {
+        if (!File(fileGraph).exists()) {
+            throw FileNotFoundException("$fileGraph not found")
+        }
+    }
+}

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
@@ -4,9 +4,6 @@ import io.github.cdsap.projectgraphmetrics.model.GraphMetric
 import org.jgrapht.alg.scoring.BetweennessCentrality
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleDirectedGraph
-import org.jgrapht.nio.dot.DOTImporter
-import java.io.File
-import java.io.FileNotFoundException
 import java.text.DecimalFormat
 
 class GraphParser(private val fileGraph: String) {
@@ -16,12 +13,7 @@ class GraphParser(private val fileGraph: String) {
     private val heightCalculator = HeightCalculator()
 
     init {
-        checkFile()
-        val importer = DOTImporter<String, DefaultEdge>().apply {
-            setVertexFactory { it }
-        }
-        result = SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
-        importer.importGraph(result, File(fileGraph))
+        result = DotGraphLoader().load(fileGraph)
 
         val edgesParsed = result.edgeSet().map {
             it.toString().removeSurrounding("(", ")").replace(".", "_").split(" : ")
@@ -29,12 +21,6 @@ class GraphParser(private val fileGraph: String) {
         }
         edgesParsed.forEach { (from, to) -> heightCalculator.addEdge(from, to) }
         betweennessCentrality = BetweennessCentrality(result).scores
-    }
-
-    private fun checkFile() {
-        if (!File(fileGraph).exists()) {
-            throw FileNotFoundException("$fileGraph not found")
-        }
     }
 
     fun result() = result

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
@@ -1,10 +1,10 @@
 package io.github.cdsap.projectgraphmetrics.parser
 
 import io.github.cdsap.projectgraphmetrics.ProjectGraphMetrics
-import io.github.cdsap.projectgraphmetrics.parser.GraphParser
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
+import java.io.FileNotFoundException
 
 class GraphIndicatorsParserTest {
 
@@ -29,5 +29,23 @@ class GraphIndicatorsParserTest {
         assertEquals(4, graphIndicatorsParser[":layer_1:module_1_54"]?.outdegree)
         assertEquals(10, graphIndicatorsParser[":layer_1:module_1_54"]?.indegree)
         assertEquals(14.44, graphIndicatorsParser[":layer_1:module_1_54"]?.betweennessCentrality)
+    }
+
+    @Test
+    fun testMissingGraphFileThrowsFileNotFoundException() {
+        val missingFile = "missing-graph.dot"
+        val exception = assertThrows(FileNotFoundException::class.java) {
+            GraphParser(missingFile).getIndicatorsByModule()
+        }
+        assertEquals("$missingFile not found", exception.message)
+    }
+
+    @Test
+    fun testDotGraphLoaderLoadsDotFile() {
+        val file = File(this::class.java.classLoader!!.getResource("graph.dot")?.path)
+        val graph = DotGraphLoader().load(file.path)
+        assertTrue(graph.containsVertex(":layer_1:module_1_54"))
+        assertEquals(4, graph.outDegreeOf(":layer_1:module_1_54"))
+        assertEquals(10, graph.inDegreeOf(":layer_1:module_1_54"))
     }
 }


### PR DESCRIPTION
## Summary

### Problem

`projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt` currently owns file existence checks, DOTImporter setup, graph construction, edge normalization, height-node construction, and metric projection in one class. This makes the core metric behavior depend directly on `java.io.File` and JGraphT DOT import infrastructure, even though `ProjectGraphMetrics.kt` and tests only need metrics for an already loaded graph.

### Why this matters

The parser is the main core boundary of the library. Mixing file/DOT infrastructure with graph metric behavior makes focused unit tests harder and increases the cost of changing input sources later, such as accepting an in-memory graph, stream, or pre-parsed dependency model.

### Proposed change

Extract the DOT file loading responsibility into a small `DotGraphLoader` or similarly named class in the parser package, returning `SimpleDirectedGraph<String, DefaultEdge>`. Keep `GraphParser(fileGraph: String)` as the public entry point, but delegate file validation, importer setup, and `importGraph` to the loader. Leave metric calculation, `Node` height logic, and `getIndicatorsByModule()` in `GraphParser`.

### Notes

This is a small clean-architecture boundary improvement: DOT file loading is infrastructure, while metric calculation is core domain behavior. The refactor keeps the existing API intact while making the metric logic easier to test independently later.

Fixes #51

## Changes

- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/DotGraphLoader.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt`

## Verification

- `./gradlew test`
