### PR TITLE
fix: refactor cli metrics loading to use the library facade

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt
@@ -4,8 +4,8 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.file
+import io.github.cdsap.projectgraphmetrics.ProjectGraphMetrics
 import io.github.cdsap.projectgraphmetrics.cli.view.GraphViewWriter
-import io.github.cdsap.projectgraphmetrics.parser.GraphParser
 
 fun main(args: Array<String>) {
     DependenciesReport().main(args)
@@ -15,7 +15,7 @@ class DependenciesReport : CliktCommand() {
     private val file by option().file().required()
 
     override fun run() {
-        val modules = GraphParser(file.path).getIndicatorsByModule()
+        val modules = ProjectGraphMetrics(file).getMetrics()
         GraphViewWriter(modules).generate()
     }
 }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/DependenciesReportTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/DependenciesReportTest.kt
@@ -1,0 +1,69 @@
+package io.github.cdsap.projectgraphmetrics.cli
+
+import com.github.ajalt.clikt.core.main
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DependenciesReportTest {
+
+    private val generatedReports =
+        listOf(
+            File("modules_report.csv"),
+            File("modules_report.txt"),
+            File("top_ten_module_report.txt")
+        )
+    private val originalReports = generatedReports.associateWith { if (it.exists()) it.readText() else null }
+
+    @After
+    fun restoreGeneratedReports() {
+        originalReports.forEach { (file, content) ->
+            if (content == null) {
+                file.delete()
+            } else {
+                file.writeText(content)
+            }
+        }
+    }
+
+    @Test
+    fun dependenciesReportGeneratesExistingOutputFiles() {
+        val dotFile = Files.createTempFile("dependencies-report", ".dot").toFile()
+        dotFile.writeText(
+            """
+            digraph G {
+            ":app" -> ":feature"
+            ":feature" -> ":core"
+            }
+            """.trimIndent()
+        )
+
+        try {
+            DependenciesReport().main(arrayOf("--file", dotFile.path))
+
+            assertTrue(File("modules_report.csv").exists())
+            assertTrue(File("modules_report.txt").exists())
+            assertTrue(File("top_ten_module_report.txt").exists())
+            assertTrue(File("modules_report.csv").readText().contains(":app,0,1"))
+        } finally {
+            dotFile.delete()
+        }
+    }
+
+    @Test
+    fun dependenciesReportUsesLibraryFacadeInsteadOfParserImplementation() {
+        val mainSource =
+            listOf(
+                Paths.get("src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt").toFile(),
+                Paths.get("cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt").toFile()
+            ).first { it.exists() }.readText()
+
+        assertTrue(mainSource.contains("import io.github.cdsap.projectgraphmetrics.ProjectGraphMetrics"))
+        assertFalse(mainSource.contains("parser.GraphParser"))
+        assertFalse(mainSource.contains("GraphParser("))
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt:7` imports the internal `parser.GraphParser` directly, and `Main.kt:17` constructs it in the CLI command. The library already exposes `ProjectGraphMetrics` as a public facade in `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt`, but the CLI bypasses that boundary.

### Why this matters

The CLI adapter is coupled to a parsing implementation detail instead of the library's core entry point. That makes future parser changes harder because command-line wiring would need to change even when the public metrics use case stays the same.

### Proposed change

Update `DependenciesReport.run()` to call `ProjectGraphMetrics(file).getMetrics()` and remove the direct `GraphParser` import from the CLI. Keep `GraphParser` package-private in practice by only using it behind the existing facade where possible.

### Notes

Clean architecture lens: `cli` is an outer adapter and should depend on the library use-case facade, while DOT parsing remains an implementation detail inside the core library module.

Fixes #53

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/DependenciesReportTest.kt`

## Verification

- `./gradlew test`
