### PR TITLE
fix: refactor graphviewwriter to separate rendering from file output

### DIFF
--- a/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRenderer.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRenderer.kt
@@ -1,0 +1,115 @@
+package io.github.cdsap.projectgraphmetrics.cli.view
+
+import com.jakewharton.picnic.Table
+import com.jakewharton.picnic.TextAlignment
+import com.jakewharton.picnic.renderText
+import com.jakewharton.picnic.table
+import io.github.cdsap.projectgraphmetrics.model.GraphMetric
+
+class GraphReportRenderer(private val modules: Map<String, GraphMetric>) {
+
+    fun renderTopTenTable(): Table =
+        table {
+            cellStyle {
+                border = true
+                alignment = TextAlignment.MiddleLeft
+                paddingLeft = 1
+                paddingRight = 1
+            }
+            body {
+                row {
+                    cell("Top Ten Module Report") {
+                        columnSpan = 8
+                        alignment = TextAlignment.MiddleCenter
+                    }
+                }
+                row {
+                    cell("Indegree") {
+                        columnSpan = 2
+                    }
+                    cell("Outdegree") {
+                        columnSpan = 2
+                    }
+                    cell("BetweennessCentrality") {
+                        columnSpan = 2
+                    }
+                    cell("Height") {
+                        columnSpan = 2
+                    }
+                }
+                val topIndegree =
+                    modules.entries.sortedBy { it.value.indegree }.reversed()
+                        .associate { it.toPair() }.entries.take(10)
+                val topOutdegree =
+                    modules.entries.sortedBy { it.value.outdegree }.reversed()
+                        .associate { it.toPair() }.entries.take(10)
+                val topHeight =
+                    modules.entries.sortedBy { it.value.height }.reversed().associate { it.toPair() }.entries.take(
+                        10
+                    )
+                val topBC = modules.entries.sortedBy { it.value.betweennessCentrality }.reversed()
+                    .associate { it.toPair() }.entries.take(10)
+                var i = 0
+                topIndegree.forEach {
+                    row {
+                        cell(topIndegree.get(i).key)
+                        cell(topIndegree.get(i).value.indegree)
+                        cell(topOutdegree.get(i).key)
+                        cell(topOutdegree.get(i).value.outdegree)
+                        cell(topBC.get(i).key)
+                        cell(topBC.get(i).value.betweennessCentrality)
+                        cell(topHeight.get(i).key)
+                        cell(topHeight.get(i).value.height)
+                        i++
+                    }
+                }
+            }
+        }
+
+    fun renderTopTenText(): String = renderTopTenTable().renderText()
+
+    fun renderModulesText(): String =
+        table {
+            cellStyle {
+                border = true
+                alignment = TextAlignment.MiddleLeft
+                paddingLeft = 1
+                paddingRight = 1
+            }
+            body {
+                row {
+                    cell("Module")
+                    cell("Indegree")
+                    cell("Outdegree")
+                    cell("BetweennessCentrality")
+                    cell("Height")
+                }
+                modules.toSortedMap().forEach {
+                    row {
+                        cell(it.key)
+                        cell(it.value.indegree) {
+                            alignment = TextAlignment.MiddleRight
+                        }
+                        cell(it.value.outdegree) {
+                            alignment = TextAlignment.MiddleRight
+                        }
+                        cell(it.value.betweennessCentrality) {
+                            alignment = TextAlignment.MiddleRight
+                        }
+                        cell(it.value.height) {
+                            alignment = TextAlignment.MiddleRight
+                        }
+                    }
+                }
+            }
+        }.renderText()
+
+    fun renderCsv(): String {
+        val headers = "Module,Indegree,Outdegree,BetweennessCentrality,Height\n"
+        var values = ""
+        modules.toSortedMap().forEach {
+            values += "${it.key},${it.value.indegree},${it.value.outdegree},${it.value.betweennessCentrality},${it.value.height}\n"
+        }
+        return """$headers$values""".trimIndent()
+    }
+}

--- a/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphViewWriter.kt
+++ b/cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphViewWriter.kt
@@ -1,8 +1,5 @@
 package io.github.cdsap.projectgraphmetrics.cli.view
 
-import com.jakewharton.picnic.TextAlignment
-import com.jakewharton.picnic.renderText
-import com.jakewharton.picnic.table
 import io.github.cdsap.projectgraphmetrics.cli.model.FilesOutput
 import io.github.cdsap.projectgraphmetrics.model.GraphMetric
 import java.io.File
@@ -16,6 +13,8 @@ class GraphViewWriter(private val modules: Map<String, GraphMetric>) {
             topTenModuleReportTxt = "top_ten_module_report.txt"
         )
 
+    private val renderer = GraphReportRenderer(modules)
+
     fun generate() {
         printTopTenIndicatorsConsole()
         writeTopTenIndicatorsTxt()
@@ -27,114 +26,21 @@ class GraphViewWriter(private val modules: Map<String, GraphMetric>) {
         if (File(filesOutput.topTenModuleReportTxt).exists()) {
             File(filesOutput.topTenModuleReportTxt).delete()
         }
-        File(filesOutput.topTenModuleReportTxt).writeText(topTenModules().renderText())
+        File(filesOutput.topTenModuleReportTxt).writeText(renderer.renderTopTenText())
         if (File(filesOutput.topTenModuleReportTxt).exists()) {
             println("${filesOutput.topTenModuleReportTxt} created")
         }
     }
 
     private fun printTopTenIndicatorsConsole() {
-        println(topTenModules())
+        println(renderer.renderTopTenTable())
     }
-
-    private fun topTenModules() =
-        table {
-            cellStyle {
-                border = true
-                alignment = TextAlignment.MiddleLeft
-                paddingLeft = 1
-                paddingRight = 1
-            }
-            body {
-                row {
-                    cell("Top Ten Module Report") {
-                        columnSpan = 8
-                        alignment = TextAlignment.MiddleCenter
-                    }
-                }
-                row {
-                    cell("Indegree") {
-                        columnSpan = 2
-                    }
-                    cell("Outdegree") {
-                        columnSpan = 2
-                    }
-                    cell("BetweennessCentrality") {
-                        columnSpan = 2
-                    }
-                    cell("Height") {
-                        columnSpan = 2
-                    }
-                }
-                val topIndegree =
-                    modules.entries.sortedBy { it.value.indegree }.reversed()
-                        .associate { it.toPair() }.entries.take(10)
-                val topOutdegree =
-                    modules.entries.sortedBy { it.value.outdegree }.reversed()
-                        .associate { it.toPair() }.entries.take(10)
-                val topHeight =
-                    modules.entries.sortedBy { it.value.height }.reversed().associate { it.toPair() }.entries.take(
-                        10
-                    )
-                val topBC = modules.entries.sortedBy { it.value.betweennessCentrality }.reversed()
-                    .associate { it.toPair() }.entries.take(10)
-                var i = 0
-                topIndegree.forEach {
-                    row {
-                        cell(topIndegree.get(i).key)
-                        cell(topIndegree.get(i).value.indegree)
-                        cell(topOutdegree.get(i).key)
-                        cell(topOutdegree.get(i).value.outdegree)
-                        cell(topBC.get(i).key)
-                        cell(topBC.get(i).value.betweennessCentrality)
-                        cell(topHeight.get(i).key)
-                        cell(topHeight.get(i).value.height)
-                        i++
-                    }
-                }
-            }
-        }
 
     private fun writeTxt() {
         if (File(filesOutput.moduleReportTxt).exists()) {
             File(filesOutput.moduleReportTxt).delete()
         }
-        File(filesOutput.moduleReportTxt).writeText(
-            table {
-                cellStyle {
-                    border = true
-                    alignment = TextAlignment.MiddleLeft
-                    paddingLeft = 1
-                    paddingRight = 1
-                }
-                body {
-                    row {
-                        cell("Module")
-                        cell("Indegree")
-                        cell("Outdegree")
-                        cell("BetweennessCentrality")
-                        cell("Height")
-                    }
-                    modules.toSortedMap().forEach {
-                        row {
-                            cell(it.key)
-                            cell(it.value.indegree) {
-                                alignment = TextAlignment.MiddleRight
-                            }
-                            cell(it.value.outdegree) {
-                                alignment = TextAlignment.MiddleRight
-                            }
-                            cell(it.value.betweennessCentrality) {
-                                alignment = TextAlignment.MiddleRight
-                            }
-                            cell(it.value.height) {
-                                alignment = TextAlignment.MiddleRight
-                            }
-                        }
-                    }
-                }
-            }.renderText()
-        )
+        File(filesOutput.moduleReportTxt).writeText(renderer.renderModulesText())
         if (File(filesOutput.moduleReportTxt).exists()) {
             println("${filesOutput.moduleReportTxt} created")
         }
@@ -144,12 +50,7 @@ class GraphViewWriter(private val modules: Map<String, GraphMetric>) {
         if (File(filesOutput.moduleReportCsv).exists()) {
             File(filesOutput.moduleReportCsv).delete()
         }
-        val headers = "Module,Indegree,Outdegree,BetweennessCentrality,Height\n"
-        var values = ""
-        modules.toSortedMap().forEach {
-            values += "${it.key},${it.value.indegree},${it.value.outdegree},${it.value.betweennessCentrality},${it.value.height}\n"
-        }
-        File(filesOutput.moduleReportCsv).writeText("""$headers$values""".trimIndent())
+        File(filesOutput.moduleReportCsv).writeText(renderer.renderCsv())
         if (File(filesOutput.moduleReportCsv).exists()) {
             println("${filesOutput.moduleReportCsv} created")
         }

--- a/cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRendererTest.kt
+++ b/cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRendererTest.kt
@@ -1,0 +1,103 @@
+package io.github.cdsap.projectgraphmetrics.cli.view
+
+import com.jakewharton.picnic.renderText
+import io.github.cdsap.projectgraphmetrics.model.GraphMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class GraphReportRendererTest {
+
+    private val modules =
+        mapOf(
+            ":core" to GraphMetric(height = 1, betweennessCentrality = 0.0, indegree = 2, outdegree = 0),
+            ":feature" to GraphMetric(height = 2, betweennessCentrality = 1.5, indegree = 1, outdegree = 1),
+            ":app" to GraphMetric(height = 3, betweennessCentrality = 0.5, indegree = 0, outdegree = 2)
+        )
+
+    @Test
+    fun renderCsvProducesSortedModuleRowsWithoutTouchingFilesystem() {
+        val before = snapshotReportFiles()
+
+        val csv = GraphReportRenderer(modules).renderCsv()
+
+        assertEquals(
+            """
+            Module,Indegree,Outdegree,BetweennessCentrality,Height
+            :app,0,2,0.5,3
+            :core,2,0,0.0,1
+            :feature,1,1,1.5,2
+            """.trimIndent(),
+            csv
+        )
+        assertReportFilesUnchanged(before)
+    }
+
+    @Test
+    fun renderModulesTextIncludesAllModulesAndHeadersWithoutTouchingFilesystem() {
+        val before = snapshotReportFiles()
+
+        val text = GraphReportRenderer(modules).renderModulesText()
+
+        assertTrue(text.contains("Module"))
+        assertTrue(text.contains("Indegree"))
+        assertTrue(text.contains("Outdegree"))
+        assertTrue(text.contains("BetweennessCentrality"))
+        assertTrue(text.contains("Height"))
+        assertTrue(text.contains(":app"))
+        assertTrue(text.contains(":core"))
+        assertTrue(text.contains(":feature"))
+        assertTrue(text.contains("0.5"))
+        assertReportFilesUnchanged(before)
+    }
+
+    @Test
+    fun renderTopTenTextIncludesTitleAndTopModulesWithoutTouchingFilesystem() {
+        val before = snapshotReportFiles()
+
+        val text = GraphReportRenderer(modules).renderTopTenText()
+
+        assertTrue(text.contains("Top Ten Module Report"))
+        assertTrue(text.contains("Indegree"))
+        assertTrue(text.contains("Outdegree"))
+        assertTrue(text.contains("BetweennessCentrality"))
+        assertTrue(text.contains("Height"))
+        assertTrue(text.contains(":core"))
+        assertTrue(text.contains(":app"))
+        assertTrue(text.contains(":feature"))
+        assertReportFilesUnchanged(before)
+    }
+
+    @Test
+    fun renderTopTenTableMatchesRenderTopTenText() {
+        val renderer = GraphReportRenderer(modules)
+        assertEquals(renderer.renderTopTenTable().renderText(), renderer.renderTopTenText())
+    }
+
+    private fun snapshotReportFiles(): Map<File, String?> {
+        return reportFiles.associateWith { if (it.exists()) it.readText() else null }
+    }
+
+    private fun assertReportFilesUnchanged(before: Map<File, String?>) {
+        before.forEach { (file, content) ->
+            val after = if (file.exists()) file.readText() else null
+            assertEquals("Unexpected filesystem change for ${file.name}", content, after)
+        }
+        reportFiles.forEach { file ->
+            if (before[file] == null) {
+                assertFalse(file.exists())
+            }
+        }
+    }
+
+    companion object {
+        private val reportFiles =
+            listOf(
+                File("modules_report.csv"),
+                File("modules_report.txt"),
+                File("top_ten_module_report.txt")
+            )
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphViewWriter.kt` mixes three responsibilities in one class: choosing report filenames, rendering Picnic/text/CSV report content, and writing/deleting files via `java.io.File`. Because the report content is built inside private write methods, the CLI presentation logic cannot be tested without touching the filesystem.

### Why this matters

The CLI is infrastructure around the core graph metrics domain. Keeping rendering coupled to file I/O makes small formatting changes riskier, encourages tests to assert generated files instead of pure report content, and makes it harder to reuse the same report renderer for console output, file output, or future integrations.

### Proposed change

Keep `GraphViewWriter.generate()` behavior unchanged, but extract pure rendering functions for the top-ten text report, full text report, and CSV report. The existing file-writing methods should call those renderers and remain responsible only for writing to the configured output paths. This can be done inside `GraphViewWriter` first, or by introducing a small `GraphReportRenderer` in the CLI view package if that matches the local style.

### Notes

Clean architecture lens: the CLI file system side effect is infrastructure, while transforming `Map<String, GraphMetric>` into report text is presentation logic. Splitting those responsibilities is a small boundary clarification without changing the public API or the core metrics behavior.

Fixes #55

## Changes

- `cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRenderer.kt`
- `cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphViewWriter.kt`
- `cli/src/test/kotlin/io/github/cdsap/projectgraphmetrics/cli/view/GraphReportRendererTest.kt`

## Verification

- `./gradlew test`
