### PR TITLE
fix: refactor graph height calculation to isolate metric behavior

### DIFF
--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculator.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculator.kt
@@ -1,7 +1,13 @@
 package io.github.cdsap.projectgraphmetrics.parser
 
-internal class HeightCalculator {
+internal class GraphHeightCalculator(
+    edges: List<Pair<String, String>> = emptyList()
+) {
     private val nodes = mutableMapOf<String, Node>()
+
+    init {
+        edges.forEach { (from, to) -> addEdge(from, to) }
+    }
 
     fun addEdge(from: String, to: String) {
         getOrCreate(from).dependsOn.add(getOrCreate(to))

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
@@ -10,7 +10,7 @@ class GraphParser(private val fileGraph: String) {
     private val decimalFormat = DecimalFormat("#.##")
     private val result: SimpleDirectedGraph<String, DefaultEdge>
     private val betweennessCentrality: Map<String, Double>
-    private val heightCalculator = HeightCalculator()
+    private val heightCalculator: GraphHeightCalculator
 
     init {
         result = DotGraphLoader().load(fileGraph)
@@ -19,7 +19,7 @@ class GraphParser(private val fileGraph: String) {
             it.toString().removeSurrounding("(", ")").replace(".", "_").split(" : ")
                 .let { parts -> parts[0] to parts[1] }
         }
-        edgesParsed.forEach { (from, to) -> heightCalculator.addEdge(from, to) }
+        heightCalculator = GraphHeightCalculator(edgesParsed)
         betweennessCentrality = BetweennessCentrality(result).scores
     }
 

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculatorTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculatorTest.kt
@@ -4,13 +4,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class HeightCalculatorTest {
+class GraphHeightCalculatorTest {
 
     @Test
     fun heightOfSimpleDependencyChain() {
-        val calculator = HeightCalculator()
-        calculator.addEdge("A", "B")
-        calculator.addEdge("B", "C")
+        val calculator = GraphHeightCalculator(
+            listOf("A" to "B", "B" to "C")
+        )
 
         assertEquals(0, calculator.heightOf("C"))
         assertEquals(1, calculator.heightOf("B"))
@@ -19,15 +19,14 @@ class HeightCalculatorTest {
 
     @Test
     fun heightOfUnknownModuleIsMinusOne() {
-        val calculator = HeightCalculator()
-        calculator.addEdge("A", "B")
+        val calculator = GraphHeightCalculator(listOf("A" to "B"))
 
         assertEquals(-1, calculator.heightOf("missing"))
     }
 
     @Test
     fun cycleGuardReturnsFiniteHeight() {
-        val calculator = HeightCalculator()
+        val calculator = GraphHeightCalculator()
         calculator.addEdge("A", "B")
         calculator.addEdge("B", "A")
 
@@ -38,5 +37,12 @@ class HeightCalculatorTest {
         assertTrue(heightB >= 0)
         assertEquals(2, heightA)
         assertEquals(1, heightB)
+    }
+
+    @Test
+    fun heightOfEmptyEdgeListIsMinusOne() {
+        val calculator = GraphHeightCalculator(emptyList())
+
+        assertEquals(-1, calculator.heightOf("A"))
     }
 }


### PR DESCRIPTION
## Summary

### Problem

`projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt` currently handles DOT file validation/import, JGraphT graph construction, betweenness scoring, degree lookups, and the custom height traversal via the nested `Node` type and `nodes` cache. That mixes infrastructure parsing concerns with core metric behavior in one class.

### Why this matters

The height algorithm is domain behavior but is only testable through file-based DOT parsing today. Keeping it embedded in `GraphParser` makes future metric fixes harder to validate without exercising importer and filesystem concerns at the same time.

### Proposed change

Extract the `Node`, `addEdge`, `getOrCreate`, and `heightOf` logic into a small package-private/internal height calculator class that accepts parsed edges or a graph-derived edge list, then have `GraphParser` delegate height calculation to it after DOT import. Preserve the existing public API and output values.

### Notes

From a clean architecture lens, DOT import and filesystem validation are infrastructure concerns, while height calculation is core graph metric behavior. This extraction clarifies that boundary without changing modules, dependencies, or public API.

Fixes #58

## Changes

- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculator.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculator.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculatorTest.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/HeightCalculatorTest.kt`

## Verification

- `./gradlew test`
