### PR TITLE
fix: refactor graphparser to separate dot loading from metric calculatio

### DIFF
--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt
@@ -1,12 +1,14 @@
 package io.github.cdsap.projectgraphmetrics
 
 import io.github.cdsap.projectgraphmetrics.model.GraphMetric
+import io.github.cdsap.projectgraphmetrics.parser.DotGraphLoader
 import io.github.cdsap.projectgraphmetrics.parser.GraphParser
 import java.io.File
 
 class ProjectGraphMetrics(private val file: File) {
 
     fun getMetrics(): Map<String, GraphMetric> {
-        return GraphParser(file.path).getIndicatorsByModule()
+        val graph = DotGraphLoader().load(file.path)
+        return GraphParser(graph).getIndicatorsByModule()
     }
 }

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
@@ -6,15 +6,14 @@ import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleDirectedGraph
 import java.text.DecimalFormat
 
-class GraphParser(private val fileGraph: String) {
+class GraphParser(private val result: SimpleDirectedGraph<String, DefaultEdge>) {
     private val decimalFormat = DecimalFormat("#.##")
-    private val result: SimpleDirectedGraph<String, DefaultEdge>
     private val betweennessCentrality: Map<String, Double>
     private val heightCalculator: GraphHeightCalculator
 
-    init {
-        result = DotGraphLoader().load(fileGraph)
+    constructor(fileGraph: String) : this(DotGraphLoader().load(fileGraph))
 
+    init {
         val edgesParsed = result.edgeSet().map {
             it.toString().removeSurrounding("(", ")").replace(".", "_").split(" : ")
                 .let { parts -> parts[0] to parts[1] }

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
@@ -1,6 +1,8 @@
 package io.github.cdsap.projectgraphmetrics.parser
 
 import io.github.cdsap.projectgraphmetrics.ProjectGraphMetrics
+import org.jgrapht.graph.DefaultEdge
+import org.jgrapht.graph.SimpleDirectedGraph
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
@@ -47,5 +49,37 @@ class GraphIndicatorsParserTest {
         assertTrue(graph.containsVertex(":layer_1:module_1_54"))
         assertEquals(4, graph.outDegreeOf(":layer_1:module_1_54"))
         assertEquals(10, graph.inDegreeOf(":layer_1:module_1_54"))
+    }
+
+    @Test
+    fun testMetricsFromAlreadyLoadedGraph() {
+        val file = File(this::class.java.classLoader!!.getResource("graph.dot")?.path)
+        val loadedGraph = DotGraphLoader().load(file.path)
+        val metrics = GraphParser(loadedGraph).getIndicatorsByModule()
+
+        assertEquals(1, metrics[":layer_1:module_1_54"]?.height)
+        assertEquals(4, metrics[":layer_1:module_1_54"]?.outdegree)
+        assertEquals(10, metrics[":layer_1:module_1_54"]?.indegree)
+        assertEquals(14.44, metrics[":layer_1:module_1_54"]?.betweennessCentrality)
+    }
+
+    @Test
+    fun testMetricsFromInMemoryGraph() {
+        val graph = SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
+        graph.addVertex(":app")
+        graph.addVertex(":feature")
+        graph.addVertex(":core")
+        graph.addEdge(":app", ":feature")
+        graph.addEdge(":feature", ":core")
+
+        val metrics = GraphParser(graph).getIndicatorsByModule()
+
+        assertEquals(2, metrics[":app"]?.height)
+        assertEquals(1, metrics[":feature"]?.height)
+        assertEquals(0, metrics[":core"]?.height)
+        assertEquals(1, metrics[":app"]?.outdegree)
+        assertEquals(0, metrics[":app"]?.indegree)
+        assertEquals(0.0, metrics[":app"]?.betweennessCentrality)
+        assertEquals(1.0, metrics[":feature"]?.betweennessCentrality)
     }
 }


### PR DESCRIPTION
## Summary

### Problem

`GraphParser` (`projectgraphmetrics/.../parser/GraphParser.kt`) mixes infrastructure and core behavior in one type: filesystem checks (`checkFile()` / `File(fileGraph)`), JGraphT `DOTImporter` I/O, dual graph construction (JGraphT + internal `Node` height tree), and metric assembly in `getIndicatorsByModule()`. `ProjectGraphMetrics` only re-wraps a path string into that same constructor, so the library’s domain API remains file-path-bound.

### Why this matters

Metric logic cannot be unit-tested without real `.dot` files on disk, and any change to import/I/O risks regressing height, degree, and betweenness behavior. The blurred boundary also leaves two entry points (`ProjectGraphMetrics` vs `GraphParser`) that both funnel through the same coupled constructor.

### Proposed change

Extract a small DOT-loading helper (e.g. `DotGraphLoader` or a `GraphParser.fromFile(...)` factory) that only validates the file and returns the imported `SimpleDirectedGraph`. Keep metric calculation (degrees, betweenness, height/`Node` tree, `getIndicatorsByModule()`) on a type that accepts an already-loaded graph. Wire `ProjectGraphMetrics` and the CLI through the loader so public results stay identical.

### Notes

Clean-architecture cut: treat `.dot` import as infrastructure/adapter; treat module metrics (`GraphMetric`) as the core application result. This clarifies the library boundary without a rewrite or framework change.

Fixes #63

## Changes

- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt`

## Verification

- `./gradlew test`
