### PR TITLE
fix: refactor graphparser to separate dot loading from metrics calculati

### DIFF
--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt
@@ -1,14 +1,12 @@
 package io.github.cdsap.projectgraphmetrics
 
 import io.github.cdsap.projectgraphmetrics.model.GraphMetric
-import io.github.cdsap.projectgraphmetrics.parser.DotGraphLoader
 import io.github.cdsap.projectgraphmetrics.parser.GraphParser
 import java.io.File
 
 class ProjectGraphMetrics(private val file: File) {
 
     fun getMetrics(): Map<String, GraphMetric> {
-        val graph = DotGraphLoader().load(file.path)
-        return GraphParser(graph).getIndicatorsByModule()
+        return GraphParser(file.path).getIndicatorsByModule()
     }
 }

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculator.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculator.kt
@@ -1,4 +1,4 @@
-package io.github.cdsap.projectgraphmetrics.parser
+package io.github.cdsap.projectgraphmetrics.metrics
 
 internal class GraphHeightCalculator(
     edges: List<Pair<String, String>> = emptyList()

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculator.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculator.kt
@@ -1,0 +1,51 @@
+package io.github.cdsap.projectgraphmetrics.metrics
+
+import io.github.cdsap.projectgraphmetrics.model.GraphMetric
+import org.jgrapht.alg.scoring.BetweennessCentrality
+import org.jgrapht.graph.DefaultEdge
+import org.jgrapht.graph.SimpleDirectedGraph
+import java.text.DecimalFormat
+
+class GraphMetricsCalculator(
+    private val graph: SimpleDirectedGraph<String, DefaultEdge>
+) {
+    private val decimalFormat = DecimalFormat("#.##")
+    private val betweennessCentrality: Map<String, Double>
+    private val heightCalculator: GraphHeightCalculator
+
+    init {
+        val edgesParsed = graph.edgeSet().map { edge ->
+            graph.getEdgeSource(edge) to graph.getEdgeTarget(edge)
+        }
+        heightCalculator = GraphHeightCalculator(edgesParsed)
+        betweennessCentrality = BetweennessCentrality(graph).scores
+    }
+
+    fun getIndicatorsByModule(): Map<String, GraphMetric> {
+        return graph.vertexSet().associateWith {
+            GraphMetric(
+                height = heightOf(it),
+                indegree = inDegree(it),
+                outdegree = outDegree(it),
+                betweennessCentrality = betweennessCentrality(it)
+            )
+        }
+    }
+
+    private fun betweennessCentrality(module: String) =
+        decimalFormat.format(betweennessCentrality[module] ?: 0.0).toDouble()
+
+    private fun inDegree(module: String) = try {
+        graph.inDegreeOf(module)
+    } catch (e: IllegalArgumentException) {
+        0
+    }
+
+    private fun outDegree(module: String) = try {
+        graph.outDegreeOf(module)
+    } catch (e: IllegalArgumentException) {
+        0
+    }
+
+    private fun heightOf(key: String): Int = heightCalculator.heightOf(key)
+}

--- a/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
+++ b/projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt
@@ -1,54 +1,17 @@
 package io.github.cdsap.projectgraphmetrics.parser
 
+import io.github.cdsap.projectgraphmetrics.metrics.GraphMetricsCalculator
 import io.github.cdsap.projectgraphmetrics.model.GraphMetric
-import org.jgrapht.alg.scoring.BetweennessCentrality
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleDirectedGraph
-import java.text.DecimalFormat
 
 class GraphParser(private val result: SimpleDirectedGraph<String, DefaultEdge>) {
-    private val decimalFormat = DecimalFormat("#.##")
-    private val betweennessCentrality: Map<String, Double>
-    private val heightCalculator: GraphHeightCalculator
 
     constructor(fileGraph: String) : this(DotGraphLoader().load(fileGraph))
 
-    init {
-        val edgesParsed = result.edgeSet().map {
-            it.toString().removeSurrounding("(", ")").replace(".", "_").split(" : ")
-                .let { parts -> parts[0] to parts[1] }
-        }
-        heightCalculator = GraphHeightCalculator(edgesParsed)
-        betweennessCentrality = BetweennessCentrality(result).scores
-    }
-
     fun result() = result
 
-    fun betweennessCentrality(module: String) =
-        decimalFormat.format(betweennessCentrality[module] ?: 0.0).toDouble()
-
-    fun inDegree(module: String) = try {
-        result.inDegreeOf(module)
-    } catch (e: IllegalArgumentException) {
-        0
-    }
-
-    fun outDegree(module: String) = try {
-        result.outDegreeOf(module)
-    } catch (e: IllegalArgumentException) {
-        0
-    }
-
-    fun heightOf(key: String): Int = heightCalculator.heightOf(key)
-
     fun getIndicatorsByModule(): Map<String, GraphMetric> {
-        return result().vertexSet().associateWith {
-            GraphMetric(
-                height = heightOf(it),
-                indegree = inDegree(it),
-                outdegree = outDegree(it),
-                betweennessCentrality = betweennessCentrality(it)
-            )
-        }
+        return GraphMetricsCalculator(result).getIndicatorsByModule()
     }
 }

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculatorTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculatorTest.kt
@@ -1,4 +1,4 @@
-package io.github.cdsap.projectgraphmetrics.parser
+package io.github.cdsap.projectgraphmetrics.metrics
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculatorTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculatorTest.kt
@@ -1,0 +1,44 @@
+package io.github.cdsap.projectgraphmetrics.metrics
+
+import io.github.cdsap.projectgraphmetrics.parser.DotGraphLoader
+import org.jgrapht.graph.DefaultEdge
+import org.jgrapht.graph.SimpleDirectedGraph
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class GraphMetricsCalculatorTest {
+
+    @Test
+    fun metricsFromInMemoryGraphMatchExpectedValues() {
+        val graph = SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
+        graph.addVertex(":app")
+        graph.addVertex(":feature")
+        graph.addVertex(":core")
+        graph.addEdge(":app", ":feature")
+        graph.addEdge(":feature", ":core")
+
+        val metrics = GraphMetricsCalculator(graph).getIndicatorsByModule()
+
+        assertEquals(2, metrics[":app"]?.height)
+        assertEquals(1, metrics[":feature"]?.height)
+        assertEquals(0, metrics[":core"]?.height)
+        assertEquals(1, metrics[":app"]?.outdegree)
+        assertEquals(0, metrics[":app"]?.indegree)
+        assertEquals(0.0, metrics[":app"]?.betweennessCentrality)
+        assertEquals(1.0, metrics[":feature"]?.betweennessCentrality)
+    }
+
+    @Test
+    fun metricsFromLoadedDotFileMatchExpectedValues() {
+        val file = File(this::class.java.classLoader!!.getResource("graph.dot")?.path)
+        val graph = DotGraphLoader().load(file.path)
+
+        val metrics = GraphMetricsCalculator(graph).getIndicatorsByModule()
+
+        assertEquals(1, metrics[":layer_1:module_1_54"]?.height)
+        assertEquals(4, metrics[":layer_1:module_1_54"]?.outdegree)
+        assertEquals(10, metrics[":layer_1:module_1_54"]?.indegree)
+        assertEquals(14.44, metrics[":layer_1:module_1_54"]?.betweennessCentrality)
+    }
+}

--- a/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
+++ b/projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.projectgraphmetrics.parser
 
 import io.github.cdsap.projectgraphmetrics.ProjectGraphMetrics
+import io.github.cdsap.projectgraphmetrics.metrics.GraphMetricsCalculator
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleDirectedGraph
 import org.junit.Assert.*
@@ -72,7 +73,7 @@ class GraphIndicatorsParserTest {
         graph.addEdge(":app", ":feature")
         graph.addEdge(":feature", ":core")
 
-        val metrics = GraphParser(graph).getIndicatorsByModule()
+        val metrics = GraphMetricsCalculator(graph).getIndicatorsByModule()
 
         assertEquals(2, metrics[":app"]?.height)
         assertEquals(1, metrics[":feature"]?.height)
@@ -81,5 +82,18 @@ class GraphIndicatorsParserTest {
         assertEquals(0, metrics[":app"]?.indegree)
         assertEquals(0.0, metrics[":app"]?.betweennessCentrality)
         assertEquals(1.0, metrics[":feature"]?.betweennessCentrality)
+    }
+
+    @Test
+    fun testGraphParserDelegatesToMetricsCalculator() {
+        val graph = SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge::class.java)
+        graph.addVertex(":app")
+        graph.addVertex(":core")
+        graph.addEdge(":app", ":core")
+
+        val parserMetrics = GraphParser(graph).getIndicatorsByModule()
+        val calculatorMetrics = GraphMetricsCalculator(graph).getIndicatorsByModule()
+
+        assertEquals(calculatorMetrics, parserMetrics)
     }
 }


### PR DESCRIPTION
## Summary

### Problem

`GraphParser` (`projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`) combines infrastructure concerns (file existence checks, DOT import via JGraphT) with application/domain behavior (indegree/outdegree, betweenness centrality, module height via an internal `Node` graph, and `GraphMetric` assembly in `getIndicatorsByModule()`). The CLI (`cli/src/main/kotlin/io/github/cdsap/projectgraphmetrics/cli/Main.kt`) calls `GraphParser` directly, while the library facade `ProjectGraphMetrics` (`projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt`) is only a one-line pass-through, so the intended application boundary is unused and metric logic is unreachable without file I/O.

### Why this matters

Metric algorithms cannot be unit-tested in isolation without a `.dot` file on disk, and any change to parsing (e.g. the fragile edge re-parsing via `edge.toString()` at lines 26–29) risks unintended changes to metric output. This coupling increases maintenance cost and makes the core graph-metrics behavior harder to reason about or reuse.

### Proposed change

Extract a new `GraphMetricsCalculator` (e.g. under `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/`) that accepts a `SimpleDirectedGraph<String, DefaultEdge>` and returns `Map<String, GraphMetric>`, moving the `Node` height logic, betweenness scoring, and degree lookups into it. Slim `GraphParser` to file validation and DOT import only; keep `getIndicatorsByModule()` as a thin delegate to the calculator so the public API stays stable. Make `ProjectGraphMetrics` the orchestration entry point (parser + calculator) and update `Main.kt` to call `ProjectGraphMetrics(file).getMetrics()` instead of `GraphParser` directly. When building the height graph inside the calculator, prefer `graph.getEdgeSource(edge)` / `graph.getEdgeTarget(edge)` over `edge.toString()` parsing.

### Notes

From a clean-architecture lens, DOT import is an infrastructure adapter and metric computation is application/domain behavior; the dependency should flow from orchestration (`ProjectGraphMetrics`) toward a graph-in/graph-out calculator, not from metrics toward `File` paths. This is a single, behavior-preserving PR that clarifies the boundary without renaming packages or introducing interfaces unless the team wants them later.

Fixes #66

## Changes

- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/ProjectGraphMetrics.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculator.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculator.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculator.kt`
- `projectgraphmetrics/src/main/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphParser.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphHeightCalculatorTest.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/metrics/GraphMetricsCalculatorTest.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphHeightCalculatorTest.kt`
- `projectgraphmetrics/src/test/kotlin/io/github/cdsap/projectgraphmetrics/parser/GraphIndicatorsParserTest.kt`

## Verification

- `./gradlew test`
